### PR TITLE
Add missing font and disable CHUDQuickInfo

### DIFF
--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -241,6 +241,15 @@ function GM:Initialize()
 		scanlines = 0,
 		shadow = true
 	})
+	surface.CreateFont("DefaultBold", { 
+		font = "anthem",
+		size = 20,
+		weight = 400,
+		antialias = true,
+		blursize = 0,
+		scanlines = 0,
+		shadow = true
+	})
 
 	if ZSF.FORCE_NORMAL_GAMMA then
 		RunConsoleCommand("mat_monitorgamma", "2.2")
@@ -291,7 +300,7 @@ function GM:PlayerShouldTakeDamage(ply, attacker)
 end
 
 function GM:HUDShouldDraw(name)
-	return name ~= "CHudHealth" and name ~= "CHudBattery" and name ~= "CHudSecondaryAmmo"
+	return name ~= "CHudHealth" and name ~= "CHudBattery" and name ~= "CHudSecondaryAmmo" and name ~= "CHUDQuickInfo"
 end
 
 local function ReceiveTopTimes(um)


### PR DESCRIPTION
After the crosshair update by default `hud_quickinfo` is set to `1`.
This Half-Life 2 crosshair was disabled by the devs for many years which explains why it wasn't originally in the code.

DefaultBold was originally a default font that got removed, my implementation of it isn't 100% accurate.